### PR TITLE
ci: remove ubuntu 18 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-12, macos-11, windows-2022, windows-2019]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-11, windows-2022, windows-2019]
         compiler: [gcc]
         version: [12, 11, 10, 9, 8, 7, 6, 5]
     steps:


### PR DESCRIPTION
`ubuntu-18.04` runner image is [no longer supported](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/), remove it from the test matrix