### PR TITLE
ci: add macos-13 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-12, macos-11, windows-2022, windows-2019]
+        os:
+          - ubuntu-22.04
+          - ubuntu-20.04
+          - macos-13-x1
+          - macos-13
+          - macos-12
+          - macos-11
+          - windows-2022
+          - windows-2019
         toolchain:
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 11}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-20.04
-          - macos-13-x1
           - macos-13
           - macos-12
           - macos-11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-11, windows-2022, windows-2019]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-12, macos-11, windows-2022, windows-2019]
         toolchain:
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 11}


### PR DESCRIPTION
https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/