### PR TITLE
Add support for GCC 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
           - windows-2022
           - windows-2019
         toolchain:
+          - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 11}
           - {compiler: gcc, version: 10}

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ jobs:
   - *intel* (for `ifx`)
   - *intel-classic* (for `ifort`)
 - *version*: Version of the compiler toolchain, available options are
-  - *5–12* for *gcc*
+  - *5–13* for *gcc*
   - *2021.1–2023.1* for *intel*
   - *2021.1–2021.9* for *intel-classic*
+
+**Note:** version 13 of the GNU toolchain is not yet available on Windows.
 
 
 ## Outputs

--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -23,7 +23,7 @@ install_gcc_brew()
   ln -fs /usr/local/bin/g++-${version} /usr/local/bin/g++
 
   # link lib dir for previous GCC versions to avoid missing .dylib issues
-  for (( i=12; i>4; i-- ))
+  for (( i=13; i>4; i-- ))
   do
     gcc_lib_path="/usr/local/opt/gcc/lib/gcc/$i"
     if [ -d $gcc_lib_path ]; then
@@ -90,46 +90,6 @@ install_gcc_choco()
   if [ -d "$FCDIR" ] && [ -f "$LNDIR/libgfortran-5.dll" ] && [ ! -f "$FCDIR/libgfortran-5.dll" ]; then
       ln -s "$LNDIR/libgfortran-5.dll" "$FCDIR/libgfortran-5.dll"
   fi
-}
-
-install_gcc_winlibs()
-{
-  repo="https://github.com/brechtsanders/winlibs_mingw/releases/download"
-  case $version in
-    12)
-      tag="12.2.0-14.0.6-10.0.0-ucrt-r2"
-      zip="winlibs-x86_64-posix-seh-gcc-12.2.0-mingw-w64ucrt-10.0.0-r2.zip"
-      ;;
-    11)
-      tag="11.2.0-12.0.1-9.0.0-r1"
-      zip="winlibs-x86_64-posix-seh-gcc-11.2.0-mingw-w64-9.0.0-r1.zip"
-      ;;
-    10)
-      tag="10.3.0-12.0.0-9.0.0-r2"
-      zip="winlibs-x86_64-posix-seh-gcc-10.3.0-mingw-w64-9.0.0-r2.zip"
-      ;;
-    9)
-      tag="9.4.0-9.0.0-r1"
-      zip="winlibs-x86_64-posix-seh-gcc-9.4.0-mingw-w64-9.0.0-r1.zip"
-      ;;
-    8)
-      tag="8.5.0-9.0.0-r1"
-      zip="winlibs-x86_64-posix-seh-gcc-8.5.0-mingw-w64-9.0.0-r1.zip"
-      ;;
-    *)
-      echo "Unsupported version: $version (choose 8-12)"
-      exit 1
-      ;;
-  esac
-
-  require_fetch
-  $fetch "$repo/$tag/$zip" > gcc.zip
-
-  unzip -qo gcc.zip "mingw64/bin/*" -d /
-
-  export FC="gfortran"
-  export CC="gcc"
-  export CXX="g++"
 }
 
 install_gcc()


### PR DESCRIPTION
Prep to support https://gcc.gnu.org/gcc-13/changes.html. ~~Not on apt/brew/choco yet, and winlibs version is still a prerelease snapshot.~~ Will update and mark ready when available on all package managers

- [x] apt
- [X] [homebrew](https://formulae.brew.sh/formula/gcc#default)
- [ ] chocolatey
- [X] [winlibs](https://github.com/brechtsanders/winlibs_mingw/releases/tag/13.1.0posix-16.0.3-11.0.0-ucrt-r1)