### PR TITLE
docs(readme): miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,8 @@ jobs:
   - *gcc* (for `gfortran`)
   - *intel* (for `ifx`)
   - *intel-classic* (for `ifort`)
-- *version*: Version of the compiler toolchain, available options are
-  - *5–13* for *gcc*
-  - *2021.1–2023.2* for *intel*
-  - *2021.1–2021.10* for *intel-classic*
+- *version*: Version of the compiler toolchain. See [runner compatibility](#runner-compatibility) chart below.
 
-**Note:** version 13 of the GNU toolchain is not yet available on Windows.
 
 
 ## Outputs
@@ -100,6 +96,7 @@ Support for the GCC toolchain varies across GitHub-hosted runner images.
 | windows-2022 |      |      | &check; | &check; | &check; | &check; | &check; |
 <!-- compat ends -->
 
+**Note:** version 13 of the GNU toolchain is not yet available on Windows.
 
 Supported Intel toolchains:
 
@@ -109,6 +106,7 @@ Supported Intel toolchains:
 | ubuntu-\* | intel-classic  | 2021.10, 2021.9, 2021.8, <br/> 2021.7.1, 2021.7, 2021.6, 2021.5, <br/> 2021.4, 2021.3, 2021.2, 2021.1.2, 2021.1 |
 | macos-\*  | intel-classic  | 2021.10, 2021.9, 2021.8, <br/> 2021.7.1, 2021.7, 2021.6, 2021.5, <br/> 2021.4, 2021.3, 2021.2, 2021.1 |
 
+**Note:** on macOS the `intel`/`ifx` compiler option is not suppoted, only `intel-classic` with the `ifort` compiler.
 
 ## License
 


### PR DESCRIPTION
- leave versions unspecified in Options section. different for each platform and given in compatibility section 
- note limited Intel macOS support (only intel-classic)