### PR TITLE
add macos-15-intel to test matrix, drop macos-13

### DIFF
--- a/.github/compat/matrix.yml
+++ b/.github/compat/matrix.yml
@@ -1,8 +1,9 @@
 os:
   - ubuntu-24.04
   - ubuntu-22.04
+  - macos-15-intel
+  - macos-15
   - macos-14
-  - macos-13
   - windows-2025
   - windows-2022
 toolchain:
@@ -73,23 +74,23 @@ toolchain:
   - {compiler: nvidia-hpc, version: '20.7'}
 exclude:
   # intel-classic >= 2021.10.0 not available for mac
-  - os: macos-14
+  - os: macos-15-intel
     toolchain: {compiler: intel-classic, version: 2021.12.0}
-  - os: macos-13
-    toolchain: {compiler: intel-classic, version: 2021.12.0}
-  - os: macos-14
+  - os: macos-15
     toolchain: {compiler: intel-classic, version: 2021.11.0}
-  - os: macos-13
+  - os: macos-14
     toolchain: {compiler: intel-classic, version: 2021.11.0}
   # ifx not available for mac
-  - os: macos-14
+  - os: macos-15
     toolchain: {compiler: intel}
-  - os: macos-13
+  - os: macos-14
     toolchain: {compiler: intel}
   # nvidia-hpc not available for mac
-  - os: macos-14
+  - os: macos-15-intel
     toolchain: {compiler: nvidia-hpc}
-  - os: macos-13
+  - os: macos-15
+    toolchain: {compiler: nvidia-hpc}
+  - os: macos-14
     toolchain: {compiler: nvidia-hpc}
   # nvidia-hpc not available for windows
   - os: windows-2025


### PR DESCRIPTION
add testing for the new `macos-15-intel` runner (#171), also the [`macos-13` runner will be unsupported soon](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)