### PR TITLE
fix latest version support

### DIFF
--- a/.github/compat/latest-versions.sh
+++ b/.github/compat/latest-versions.sh
@@ -1,26 +1,26 @@
-# Auto-generated from .github/compat/matrix.yml
+# Auto-generated from compat.csv
 # DO NOT EDIT MANUALLY - Run .github/compat/update_latest_versions.py to regenerate
 
 # Latest supported gcc versions by runner
 LATEST_gcc_macos_14="15"
 LATEST_gcc_macos_15="15"
 LATEST_gcc_macos_15_intel="15"
-LATEST_gcc_ubuntu_22_04="14"
+LATEST_gcc_ubuntu_22_04="13"
 LATEST_gcc_ubuntu_24_04="14"
 LATEST_gcc_windows_2022="15"
 LATEST_gcc_windows_2025="15"
 
 # Latest supported intel versions by runner
-LATEST_intel_macos_15_intel="2025.2"
+LATEST_intel_macos_15_intel="2021.4"
 LATEST_intel_ubuntu_22_04="2025.2"
 LATEST_intel_ubuntu_24_04="2025.2"
 LATEST_intel_windows_2022="2025.2"
 LATEST_intel_windows_2025="2025.2"
 
 # Latest supported intel-classic versions by runner
-LATEST_intel_classic_macos_14="2021.12"
-LATEST_intel_classic_macos_15="2021.12"
-LATEST_intel_classic_macos_15_intel="2021.12"
+LATEST_intel_classic_macos_14="2021.10"
+LATEST_intel_classic_macos_15="2021.10"
+LATEST_intel_classic_macos_15_intel="2021.10"
 LATEST_intel_classic_ubuntu_22_04="2021.12"
 LATEST_intel_classic_ubuntu_24_04="2021.12"
 LATEST_intel_classic_windows_2022="2021.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,7 +267,7 @@ jobs:
 
       - name: Generate latest versions lookup table
         if: ${{ steps.diff.outputs.diff == 'true' }}
-        run: python .github/compat/update_latest_versions.py ".github/compat/matrix.yml" ".github/compat/latest-versions.sh"
+        run: python .github/compat/update_latest_versions.py ".github/compat/compat.csv" ".github/compat/latest-versions.sh"
 
       - name: Print README diff
         if: ${{ steps.diff.outputs.diff == 'true' }}


### PR DESCRIPTION
With #185 the action extracts latest versions from `matrix.yml` but it should instead get them from the compatibility database. The test matrix is what we are aiming for, the compatibility db is what is actually possible.

Fix problem described in https://github.com/fortran-lang/setup-fortran/issues/184#issuecomment-3799724294