### PR TITLE
fix: only install binutils with linuxbrew for gcc>=15

### DIFF
--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -167,9 +167,11 @@ install_gcc_brew_linux()
   setup_brew_linux
   brew install --force gcc@${resolved_version}
   # Add brew binutils to PATH (gcc-15+ requires newer assembler)
-  brew install --force binutils
-  binutils_dir=$(brew --prefix binutils)/bin
-  echo "$binutils_dir" >> $GITHUB_PATH
+  if [[ "$resolved_version" -ge 15 ]]; then
+    brew install --force binutils
+    binutils_dir=$(brew --prefix binutils)/bin
+    echo "$binutils_dir" >> $GITHUB_PATH
+  fi
   bindir=$(brew --prefix)/bin
   sudo_wrapper update-alternatives \
     --install /usr/bin/gcc gcc ${bindir}/gcc-${resolved_version} 100 \


### PR DESCRIPTION
#198 began installing binutils for gcc installed from linuxbrew on older ubuntu images. This should be conditional on gcc >= 15 as recent binutils are built against newer GLIBC than is present on the old ubuntu images.