### PR TITLE
fix: update windows-2025 detection for win25-vs2026

### DIFF
--- a/.github/compat/matrix.yml
+++ b/.github/compat/matrix.yml
@@ -4,6 +4,7 @@ os:
   - macos-26-intel
   - macos-26
   - windows-2025
+  - windows-2025-vs2026
   - windows-2022
   - windows-11-arm
 toolchain:
@@ -68,6 +69,8 @@ exclude:
   # nvidia-hpc not available on windows
   - os: windows-2025
     toolchain: {compiler: nvidia-hpc}
+  - os: windows-2025-vs2026
+    toolchain: {compiler: nvidia-hpc}
   - os: windows-2022
     toolchain: {compiler: nvidia-hpc}
   - os: windows-11-arm
@@ -88,6 +91,8 @@ exclude:
   - os: macos-26
     toolchain: {compiler: aocc}
   - os: windows-2025
+    toolchain: {compiler: aocc}
+  - os: windows-2025-vs2026
     toolchain: {compiler: aocc}
   - os: windows-2022
     toolchain: {compiler: aocc}

--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -65,7 +65,7 @@ detect_runner_os()
       win22)
         echo "windows-2022"
         ;;
-      win25)
+      win25|win25-vs2026)
         echo "windows-2025"
         ;;
       win11-arm64)


### PR DESCRIPTION
Should fix #223

I keep `win25` to be retrocompatible.
